### PR TITLE
return error when user write a invalid nodemask for ipam

### DIFF
--- a/cidrset/cidr_set_test.go
+++ b/cidrset/cidr_set_test.go
@@ -735,3 +735,46 @@ func TestCIDRSetv6(t *testing.T) {
 		})
 	}
 }
+
+func TestInvalidSubNetMaskSize(t *testing.T) {
+	cases := []struct {
+		clusterCIDRStr string
+		subNetMaskSize int
+		expectErr      bool
+		description    string
+	}{
+		{
+			clusterCIDRStr: "10.0.0.0/24",
+			subNetMaskSize: 32,
+			expectErr:      false,
+			description:    "Check valid subnet mask size with IPv4",
+		},
+		{
+			clusterCIDRStr: "2001:beef:1234:369b::/60",
+			subNetMaskSize: 64,
+			expectErr:      false,
+			description:    "Check valid subnet mask size with IPv6",
+		},
+		{
+			clusterCIDRStr: "10.0.0.0/24",
+			subNetMaskSize: 64,
+			expectErr:      true,
+			description:    "Check invalid subnet mask size with IPv4",
+		},
+		{
+			clusterCIDRStr: "2001:beef:1234:369b::/60",
+			subNetMaskSize: 130,
+			expectErr:      true,
+			description:    "Check invalid subnet mask size with IPv6",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+			a, err := NewCIDRSet(clusterCIDR, tc.subNetMaskSize)
+			if gotErr := err != nil; gotErr != tc.expectErr {
+				t.Fatalf("NewCIDRSet(%v, %v) = %v, %v; gotErr = %t, want %t", clusterCIDR, tc.subNetMaskSize, a, err, gotErr, tc.expectErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When user write a invalid nodenetmask , It will return no error. But it will return nil on call 
https://github.com/cilium/ipam/blob/2f672ef3ad54ecaef97003e66f7fd8a0608801e0/cidrset/cidr_set.go#L173

It cause this issue: https://github.com/cilium/cilium/issues/12956

I also think it better to add a error log on here to prevent return a nil value to the nodecidr list.

https://github.com/cilium/cilium/blob/758539bb0d7dec2ac4095cf4bf07ad21183fc647/pkg/ipam/allocator/podcidr/podcidr.go#L808