### PR TITLE
Use OnesCount8 from math/bits to implement countBits

### DIFF
--- a/service/allocator/utils_test.go
+++ b/service/allocator/utils_test.go
@@ -18,14 +18,21 @@ package allocator
 
 import (
 	"math/big"
-	"math/bits"
+	"testing"
 )
 
-// countBits returns the number of set bits in n
-func countBits(n *big.Int) int {
-	var count int = 0
-	for _, b := range n.Bytes() {
-		count += bits.OnesCount8(uint8(b))
+func TestCountBits(t *testing.T) {
+	tests := []struct {
+		n        *big.Int
+		expected int
+	}{
+		{n: big.NewInt(int64(0)), expected: 0},
+		{n: big.NewInt(int64(0xffffffffff)), expected: 40},
 	}
-	return count
+	for _, test := range tests {
+		actual := countBits(test.n)
+		if test.expected != actual {
+			t.Errorf("%s should have %d bits but recorded as %d", test.n, test.expected, actual)
+		}
+	}
 }


### PR DESCRIPTION
This allows to drop the 255 bytes `bitCounts` table. Also, `bits.OnesCount8`
can be intrinsified to a single instruction, e.g. on amd64.

Upstream PR: kubernetes/kubernetes#89530