### PR TITLE
ipallocator: Fix broken IPv6 conversion with leading zeros

### DIFF
--- a/service/ipallocator/allocator.go
+++ b/service/ipallocator/allocator.go
@@ -230,17 +230,17 @@ func (r *Range) contains(ip net.IP) (bool, int) {
 
 // bigForIP creates a big.Int based on the provided net.IP
 func bigForIP(ip net.IP) *big.Int {
-	b := ip.To4()
-	if b == nil {
-		b = ip.To16()
-	}
-	return big.NewInt(0).SetBytes(b)
+	// NOTE: Convert to 16-byte representation so we can
+	// handle v4 and v6 values the same way.
+	return big.NewInt(0).SetBytes(ip.To16())
 }
 
-// addIPOffset adds the provided integer offset to a base big.Int representing a
-// net.IP
+// addIPOffset adds the provided integer offset to a base big.Int representing a net.IP
+// NOTE: If you started with a v4 address and overflow it, you get a v6 result.
 func addIPOffset(base *big.Int, offset int) net.IP {
-	return net.IP(big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes())
+	r := big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes()
+	r = append(make([]byte, 16), r...)
+	return net.IP(r[len(r)-16:])
 }
 
 // calculateIPOffset calculates the integer offset of ip from base such that


### PR DESCRIPTION
This fixes a bug where GetIndexedIP would fail to produce correct IPv6 addresses if the IPv6 address contains leading zeros.

As a consequence, perfectly valid IPv6 pod CIDRs like `fd:11::/64` could not be used.

This bug has been fixed in upstream for a while: https://github.com/kubernetes/utils/pull/145

Ideally, we sync this package with upstream, as there are likely more such bugs that we have not fixed yet. But it seem upstream has moved quite far from our implementation and moved packages around, so it's unclear what changes we have applied on our side only.