### PR TITLE
cidrset: remove (*CidrSet).IsIPv6

### DIFF
--- a/cidrset/cidr_set.go
+++ b/cidrset/cidr_set.go
@@ -30,7 +30,6 @@ import (
 // CidrSet manages a set of CIDR ranges from which blocks of IPs can
 // be allocated from.
 type CidrSet struct {
-	isV6 bool
 	sync.Mutex
 	clusterCIDR     *net.IPNet
 	clusterIP       net.IP
@@ -77,9 +76,8 @@ func NewCIDRSet(clusterCIDR *net.IPNet, subNetMaskSize int) (*CidrSet, error) {
 	clusterMask := clusterCIDR.Mask
 	clusterMaskSize, _ := clusterMask.Size()
 
-	isV6 := clusterCIDR.IP.To4() == nil
 	var maxCIDRs int
-	if isV6 {
+	if clusterCIDR.IP.To4() == nil {
 		if subNetMaskSize > maxSubNetMaskSizeIPv6 {
 			return nil, ErrSubNetMaskSizeInvalid
 		}
@@ -96,7 +94,6 @@ func NewCIDRSet(clusterCIDR *net.IPNet, subNetMaskSize int) (*CidrSet, error) {
 		clusterMaskSize: clusterMaskSize,
 		maxCIDRs:        maxCIDRs,
 		subNetMaskSize:  subNetMaskSize,
-		isV6:            isV6,
 	}, nil
 }
 
@@ -157,11 +154,6 @@ func (s *CidrSet) indexToCIDRBlock(index int) *net.IPNet {
 		IP:   ip,
 		Mask: net.CIDRMask(s.subNetMaskSize, mask),
 	}
-}
-
-// IsIPv6 returns true if CidrSet only allocates IPv6 CIDRs.
-func (s *CidrSet) IsIPv6() bool {
-	return s.isV6
 }
 
 // IsFull returns true if CidrSet does not have any more available CIDRs.


### PR DESCRIPTION
This was added in commit 2e2083cde50b ("add IsIPv6 to detect if CidrSet
only allocates IPv6 CIDRs") but was never used in the Cilium code base.
It was removed [1] from the `pkg/ipam/allocator/podcidr.CIDRAllocator`
interface, so the implementation for type `*CidrSet` can be removed as
well.

[1] https://github.com/cilium/cilium#21065