### PR TITLE
cidrset: sync upstream changes

### DIFF
--- a/cidrset/cidr_set.go
+++ b/cidrset/cidr_set.go
@@ -204,7 +204,7 @@ func (s *CidrSet) inRange(cidr *net.IPNet) bool {
 	return s.clusterCIDR.Contains(cidr.IP.Mask(s.clusterCIDR.Mask)) || cidr.Contains(s.clusterCIDR.IP.Mask(cidr.Mask))
 }
 
-func (s *CidrSet) getBeginingAndEndIndices(cidr *net.IPNet) (begin, end int, err error) {
+func (s *CidrSet) getBeginningAndEndIndices(cidr *net.IPNet) (begin, end int, err error) {
 	if cidr == nil {
 		return -1, -1, fmt.Errorf("error getting indices for cluster cidr %v, cidr is nil", s.clusterCIDR)
 	}
@@ -256,7 +256,7 @@ func (s *CidrSet) getBeginingAndEndIndices(cidr *net.IPNet) (begin, end int, err
 
 // IsAllocated verifies if the given CIDR is allocated
 func (s *CidrSet) IsAllocated(cidr *net.IPNet) (bool, error) {
-	begin, end, err := s.getBeginingAndEndIndices(cidr)
+	begin, end, err := s.getBeginningAndEndIndices(cidr)
 	if err != nil {
 		return false, err
 	}
@@ -272,7 +272,7 @@ func (s *CidrSet) IsAllocated(cidr *net.IPNet) (bool, error) {
 
 // Release releases the given CIDR range.
 func (s *CidrSet) Release(cidr *net.IPNet) error {
-	begin, end, err := s.getBeginingAndEndIndices(cidr)
+	begin, end, err := s.getBeginningAndEndIndices(cidr)
 	if err != nil {
 		return err
 	}
@@ -287,7 +287,7 @@ func (s *CidrSet) Release(cidr *net.IPNet) error {
 // Occupy marks the given CIDR range as used. Occupy does not check if the CIDR
 // range was previously used.
 func (s *CidrSet) Occupy(cidr *net.IPNet) (err error) {
-	begin, end, err := s.getBeginingAndEndIndices(cidr)
+	begin, end, err := s.getBeginningAndEndIndices(cidr)
 	if err != nil {
 		return err
 	}

--- a/cidrset/cidr_set.go
+++ b/cidrset/cidr_set.go
@@ -205,14 +205,13 @@ func (s *CidrSet) inRange(cidr *net.IPNet) bool {
 }
 
 func (s *CidrSet) getBeginingAndEndIndices(cidr *net.IPNet) (begin, end int, err error) {
+	if cidr == nil {
+		return -1, -1, fmt.Errorf("error getting indices for cluster cidr %v, cidr is nil", s.clusterCIDR)
+	}
 	begin, end = 0, s.maxCIDRs-1
 	cidrMask := cidr.Mask
 	maskSize, _ := cidrMask.Size()
 	var ipSize int
-
-	if cidr == nil {
-		return -1, -1, fmt.Errorf("error getting indices for cluster cidr %v, cidr is nil", s.clusterCIDR)
-	}
 
 	if !s.inRange(cidr) {
 		return -1, -1, fmt.Errorf("cidr %v is out the range of cluster cidr %v", cidr, s.clusterCIDR)

--- a/cidrset/cidr_set.go
+++ b/cidrset/cidr_set.go
@@ -96,8 +96,6 @@ func NewCIDRSet(clusterCIDR *net.IPNet, subNetMaskSize int) (*CidrSet, error) {
 }
 
 func (s *CidrSet) String() string {
-	s.Lock()
-	defer s.Unlock()
 	return fmt.Sprintf("clusterCIDR: %s, nodeMask: %d", s.clusterCIDR.String(), s.subNetMaskSize)
 }
 
@@ -195,12 +193,6 @@ func (s *CidrSet) AllocateNext() (*net.IPNet, error) {
 // InRange returns true if the given CIDR is inside the range of the allocatable
 // CidrSet.
 func (s *CidrSet) InRange(cidr *net.IPNet) bool {
-	s.Lock()
-	defer s.Unlock()
-	return s.inRange(cidr)
-}
-
-func (s *CidrSet) inRange(cidr *net.IPNet) bool {
 	return s.clusterCIDR.Contains(cidr.IP.Mask(s.clusterCIDR.Mask)) || cidr.Contains(s.clusterCIDR.IP.Mask(cidr.Mask))
 }
 
@@ -213,7 +205,7 @@ func (s *CidrSet) getBeginningAndEndIndices(cidr *net.IPNet) (begin, end int, er
 	maskSize, _ := cidrMask.Size()
 	var ipSize int
 
-	if !s.inRange(cidr) {
+	if !s.InRange(cidr) {
 		return -1, -1, fmt.Errorf("cidr %v is out the range of cluster cidr %v", cidr, s.clusterCIDR)
 	}
 


### PR DESCRIPTION
In preparation for potentially moving the packages to github.com/cilium/cilium (cf. https://github.com/cilium/cilium/pull/25289)

Synchronize changes made in k8s the upstream package. Note that upstream also introduced the use of metrics in https://github.com/kubernetes/kubernetes/pull/90288 which we currently can't sync 1:1 because it's using k8s upstream metrics integration. Once we'd move this package to github.com/cilium/cilium we could add integrate these metrics as well.

See individual commits for details.
